### PR TITLE
Fix error: 'xmlPreferences.hasOwnProperty is not a function'

### DIFF
--- a/hooks/lib/configXmlParser.js
+++ b/hooks/lib/configXmlParser.js
@@ -51,7 +51,7 @@ function readPreferences(cordovaContext) {
 // region Private API
 
 function getTeamIdPreference(xmlPreferences) {
-  if (xmlPreferences.hasOwnProperty('ios-team-id')) {
+  if ('ios-team-id' in xmlPreferences) {
     return xmlPreferences['ios-team-id'][0]['$']['value'];
   }
 


### PR DESCRIPTION
Caused by version 0.5.0 of the [xml2js](https://www.npmjs.com/package/xml2js?activeTab=versions) package.

Fix [copied](stasgm/cordova-plugin-universal-links/commit/d1737c59d52b71d3d3c76e12dc21114f5ff03881) from and credited to @stasgm (Stanislau Shlyahtich) on Github.