### PR TITLE
Fix for ios error: `Cannot file module '...ios/cordova/lib/projectFIle.js'`

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -146,11 +146,22 @@ function loadProjectFile() {
       platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
       projectFile = platform_ios.parseProjectFile(iosPlatformPath());
     } catch(e) {
-      // try cordova 7.0 structure
-      var iosPlatformApi = require(path.join(iosPlatformPath(), '/cordova/Api'));
-      var projectFileApi = require(path.join(iosPlatformPath(), '/cordova/lib/projectFile.js'));
-      var locations = (new iosPlatformApi()).locations;
-      projectFile = projectFileApi.parse(locations);      
+      try {
+        // try cordova 7.0 structure
+        var iosPlatformApi = require(path.join(iosPlatformPath(), '/cordova/Api'));
+        var projectFileApi = require(path.join(iosPlatformPath(), '/cordova/lib/projectFile.js'));
+        var locations = (new iosPlatformApi()).locations;
+        projectFile = projectFileApi.parse(locations);    
+      } catch (e) {
+        // try cordova 7.0.1 structure. This is necessary following the release of
+        // cordova-ios MR 1203, which stopped copying .js files into /lib:
+        // https://github.com/apache/cordova-ios/pull/1203
+        var iosPlatformApi = require('cordova-ios/lib/Api.js');
+        var projectFileApi = require('cordova-ios/lib/projectFile.js');
+        platformApi = new iosPlatformApi("ios", iosPlatformPath());
+        var locations = platformApi.locations;
+        projectFile = projectFileApi.parse(locations);   
+      }  
     }
   }
 


### PR DESCRIPTION
In https://github.com/apache/cordova-ios/pull/1203, the platform stopped copying certain .js files into the /lib directory.

The error was:

```
Cannot find module '/Users/username/git/project/platforms/ios/cordova/lib/projectFile.js
Require stack:
- /Users/username/git/project/plugins/cordova-universal-links-plugin/hooks/lib/ios/xcodePreferences.js
- /Users/username/git/project/plugins/cordova-universal-links-plugin/hooks/afterPrepareHook.js
- /Users/username/.npm-global/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js
- /Users/username/.npm-global/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js
- /Users/username/.npm-global/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/plugman.js
- /Users/username/.npm-global/lib/node_modules/cordova/node_modules/cordova-lib/cordova-lib.js
- /Users/username/.npm-global/lib/node_modules/cordova/src/help.js
- /Users/username/.npm-global/lib/node_modules/cordova/src/cli.js
- /Users/username/.npm-global/lib/node_modules/cordova/bin/cordova
```

This MR works around that breaking change by accessing the functionality directly from the node_modules require. This approach was suggested in the linked pull request.